### PR TITLE
Update GitHub page to remove 'New' label and right-align others

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,13 +140,19 @@
                 <div class="profile-section">
                     <h2 class="mb-4">最近の活動</h2>
                     <ul class="list-group list-group-flush">
-                        <li class="list-group-item">サンプルサイト1 <span class="badge badge-primary badge-pill">New</span></li>
-                        <li class="list-group-item">サンプルサイト2 <span class="badge badge-primary badge-pill">New</span></li>
-                        <li class="list-group-item">サンプルサイト3 <span class="badge badge-primary badge-pill">New</span></li>
                         <li class="list-group-item d-flex justify-content-between align-items-center">
-                            GitHubページを更新
+                            サンプルサイト1
                             <span class="badge badge-primary badge-pill">New</span>
                         </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            サンプルサイト2
+                            <span class="badge badge-primary badge-pill">New</span>
+                        </li>
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            サンプルサイト3
+                            <span class="badge badge-primary badge-pill">New</span>
+                        </li>
+                        <li class="list-group-item">GitHubページを更新</li>
                         <li class="list-group-item">Reactのクロックサンプルを作成</li>
                         <li class="list-group-item">PWAサンプルの実装</li>
                         <li class="list-group-item">愛犬のページを作成</li>


### PR DESCRIPTION
Remove the 'New' label for 'GitHubページを更新' and right-align the 'New' labels for 'サンプルサイト1', 'サンプルサイト2', and 'サンプルサイト3' in `index.html`.

* Remove the 'New' label for 'GitHubページを更新'.
* Right-align the 'New' labels for 'サンプルサイト1', 'サンプルサイト2', and 'サンプルサイト3' within their respective boxes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/katzkawai/katzkawai.github.io/pull/3?shareId=68ab9213-5ea3-4155-8e44-dabbfd627767).