### PR TITLE
ページをもう少し派手にする

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,19 +5,20 @@
 :root {
     --bg:        #f6f7fb;
     --surface:   #ffffff;
-    --text:      #1f2433;
+   --text:      #0f1724;
     --muted:     #5b6478;
-    --accent:    #6366f1;
-    --accent-2:  #8b5cf6;
-    --accent-grad: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-    --border:    #e7e9f2;
-    --shadow-sm: 0 1px 3px rgba(20, 22, 60, .06);
-    --shadow:    0 8px 30px rgba(20, 22, 60, .08);
-    --shadow-lg: 0 18px 50px rgba(99, 102, 241, .18);
-    --radius:    16px;
-    --radius-sm: 10px;
-    --container: 1040px;
-    --header-h:  64px;
+   --accent:    #7c3aed;
+   --accent-2:  #ec4899;
+   --accent-grad: linear-gradient(135deg, #7c3aed 0%, #ec4899 100%);
+   --accent-glow: 0 8px 30px rgba(236,72,153,0.14);
+   --border:    #e7e9f2;
+   --shadow-sm: 0 1px 3px rgba(20, 22, 60, .06);
+   --shadow:    0 10px 40px rgba(99, 102, 241, .12);
+   --shadow-lg: 0 22px 60px rgba(124, 58, 237, .22);
+   --radius:    16px;
+   --radius-sm: 10px;
+   --container: 1040px;
+   --header-h:  64px;
 }
 
 * { box-sizing: border-box; }
@@ -142,33 +143,44 @@ img { max-width: 100%; height: auto; }
     overflow: hidden;
     background: var(--accent-grad);
     color: #fff;
-    padding: 72px 0 80px;
+    padding: 84px 0 96px;
     text-align: center;
+    transition: transform .35s ease;
 }
 .hero::after {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at 20% 20%, rgba(255,255,255,.18), transparent 45%),
-                radial-gradient(circle at 80% 0%, rgba(255,255,255,.12), transparent 40%);
+    background: radial-gradient(circle at 10% 10%, rgba(255,255,255,.22), transparent 30%),
+                radial-gradient(circle at 90% 0%, rgba(255,255,255,.14), transparent 35%);
     pointer-events: none;
+    mix-blend-mode: overlay;
+    animation: hero-shimmer 8s linear infinite;
+}
+@keyframes hero-shimmer {
+    0% { transform: translateX(-8%); opacity: .9; }
+    50% { transform: translateX(8%); opacity: .95; }
+    100% { transform: translateX(-8%); opacity: .9; }
 }
 .hero h1 {
     margin: 0 0 .4em;
     font-size: clamp(2rem, 5vw, 3rem);
-    font-weight: 800;
-    letter-spacing: -.5px;
+    font-weight: 900;
+    letter-spacing: -.6px;
+    text-shadow: 0 6px 24px rgba(0,0,0,.18);
 }
-.hero p { margin: 0 auto; max-width: 620px; font-size: 1.15rem; opacity: .95; }
+.hero p { margin: 0 auto; max-width: 640px; font-size: 1.15rem; opacity: .98; text-shadow: 0 2px 8px rgba(0,0,0,.12); }
 
 .hero-avatar {
-    width: 132px; height: 132px;
+    width: 144px; height: 144px;
     border-radius: 50%;
     object-fit: cover;
-    border: 4px solid rgba(255,255,255,.85);
-    box-shadow: 0 10px 30px rgba(0,0,0,.2);
+    border: 5px solid rgba(255,255,255,.95);
+    box-shadow: var(--accent-glow);
     margin-bottom: 24px;
     background: #fff;
+    transform: translateY(0);
+    transition: transform .45s cubic-bezier(.2,.9,.3,1);
 }
 
 /* ページ見出し（下層ページ） */
@@ -196,8 +208,10 @@ img { max-width: 100%; height: auto; }
     transition: transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease;
     text-decoration: none;
 }
-.btn-primary { background: var(--accent-grad); color: #fff; box-shadow: var(--shadow); }
-.btn-primary:hover { color: #fff; transform: translateY(-2px); box-shadow: var(--shadow-lg); }
+.btn-primary { background: var(--accent-grad); color: #fff; box-shadow: var(--accent-glow); position: relative; overflow: hidden; }
+.btn-primary::after { content: ''; position: absolute; inset: -40%; background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.12), transparent 20%), radial-gradient(circle at 70% 70%, rgba(255,255,255,.06), transparent 25%); transform: translateX(-30%); transition: transform .6s ease; }
+.btn-primary:hover { color: #fff; transform: translateY(-3px); box-shadow: var(--shadow-lg); }
+.btn-primary:hover::after { transform: translateX(30%); }
 .btn-ghost {
     background: transparent;
     color: #fff;


### PR DESCRIPTION
概要
---
ユーザー要望: 「もう少し派手なページにしよう」

このブランチは、サイトをより華やかにするための変更をまとめるための feature ブランチです。
現在は main から分岐した段階で、差分がない場合はこのプルリクは作成できない可能性があります。

提案する変更例
- トップページのアクセント色やグラデーションを強める
- CTA ボタンのスタイルを目立たせる（サイズ・影・アニメーション）
- hero セクションに軽いアニメーションや装飾を追加
- 重要な画像やアイコンを差し替え（imgs/ に追加）

検証方法
- ブラウザでローカルサーバを立てて表示を確認（python -m http.server）
- モバイル/デスクトップでの見え方をチェック

備考
- まだ差分が無い場合は、まず変更を行いコミットしてから再度 PR を作成してください。
- 作業を進める場合、関連ファイル: index.html, style.css, js/main.js, includes/navbar.html などを編集してください。

User instruction: もう少し派手なページにしよう
